### PR TITLE
Lmb 1532 | summary fields should be ordered

### DIFF
--- a/addon/components/semantic-forms/instance-table.hbs
+++ b/addon/components/semantic-forms/instance-table.hbs
@@ -169,12 +169,12 @@
   as |Modal|
 >
   <Modal.Body>
-      <SemanticForms::TableColumnConfigurator
-        @labels={{this.configurableLabels}}
-        @selectedLabelsOnLoad={{this.labels}}
-        @onSelectionUpdated={{this.updateTable}}
-        @disabledSelection={{this.isTableLoading}}
-      />
+    <SemanticForms::TableColumnConfigurator
+      @labels={{this.configurableLabels}}
+      @selectedLabelsOnLoad={{this.labels}}
+      @onSelectionUpdated={{this.updateTable}}
+      @disabledSelection={{this.isTableLoading}}
+    />
   </Modal.Body>
 </AuModal>
 

--- a/addon/components/semantic-forms/instance-table.hbs
+++ b/addon/components/semantic-forms/instance-table.hbs
@@ -17,7 +17,7 @@
         @alignment="center"
       >
         {{yield to="extraActions"}}
-        {{#if @labels}}
+        {{#if this.configurableLabels}}
           <AuButton
             role="menuitem"
             @skin="link"
@@ -170,7 +170,7 @@
 >
   <Modal.Body>
     <SemanticForms::TableColumnConfigurator
-      @labels={{@labels}}
+      @labels={{this.configurableLabels}}
       @selectedLabelsOnLoad={{this.labels}}
       @onSelectionUpdated={{this.updateTable}}
       @disabledSelection={{this.isTableLoading}}

--- a/addon/components/semantic-forms/instance-table.hbs
+++ b/addon/components/semantic-forms/instance-table.hbs
@@ -78,14 +78,14 @@
   >
     <t.content as |c|>
       <c.header>
-        {{#each this.formInfo.headers as |header|}}
-          {{#if header.isCustom}}
-            <th>{{header.label}}</th>
+        {{#each this.labels as |label|}}
+          {{#if label.isCustom}}
+            <th>{{label.name}}</th>
           {{else}}
             <AuDataTableThSortable
-              @field={{header.key}}
+              @field={{label.var}}
               @currentSorting={{@sort}}
-              @label={{header.label}}
+              @label={{label.name}}
             />
           {{/if}}
         {{/each}}
@@ -96,7 +96,7 @@
       <c.body as |row|>
         <SemanticForms::InstanceTableRow
           @instance={{row}}
-          @labels={{this.formInfo.labels}}
+          @labels={{this.labels}}
         />
 
         <td class="au-u-1-8 au-u-text-center">
@@ -169,12 +169,12 @@
   as |Modal|
 >
   <Modal.Body>
-    <SemanticForms::TableColumnConfigurator
-      @labels={{this.configurableLabels}}
-      @selectedLabelsOnLoad={{this.labels}}
-      @onSelectionUpdated={{this.updateTable}}
-      @disabledSelection={{this.isTableLoading}}
-    />
+      <SemanticForms::TableColumnConfigurator
+        @labels={{this.configurableLabels}}
+        @selectedLabelsOnLoad={{this.labels}}
+        @onSelectionUpdated={{this.updateTable}}
+        @disabledSelection={{this.isTableLoading}}
+      />
   </Modal.Body>
 </AuModal>
 

--- a/addon/components/semantic-forms/instance-table.js
+++ b/addon/components/semantic-forms/instance-table.js
@@ -17,6 +17,7 @@ export default class FormInstanceTableComponent extends Component {
 
   @tracked formInfo = null;
   @tracked labels = A();
+  @tracked configurableLabels = A();
 
   @tracked isDeleteModalOpen;
   @tracked isDeleting;
@@ -87,7 +88,7 @@ export default class FormInstanceTableComponent extends Component {
   @action
   async loadTable() {
     this.isTableLoading = true;
-    const formInfo = await this.semanticFormRepository.fetchInstances(
+    this.formInfo = await this.semanticFormRepository.fetchInstances(
       this.args.formDefinition,
       {
         page: this.args.page,
@@ -97,7 +98,9 @@ export default class FormInstanceTableComponent extends Component {
         labels: this.labels,
       }
     );
-    this.formInfo = formInfo;
+    this.configurableLabels = await this.semanticFormRepository.getHeaderLabels(
+      this.args.formDefinition.id
+    );
     this.isTableLoading = false;
   }
 

--- a/addon/components/semantic-forms/table-column-configurator.hbs
+++ b/addon/components/semantic-forms/table-column-configurator.hbs
@@ -15,26 +15,28 @@
             role="button"
             class="au-u-flex au-u-flex--vertical-center"
           >{{label.name}}</p>
-          <div
-            class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex-self-end"
-          >
-            <AuButton
-              @skin="naked"
-              @icon="nav-up"
-              @hideText={{true}}
-              {{on "click" (fn this.moveLabel label "up")}}
+          {{#if label.isSelected}}
+            <div
+              class="au-u-flex au-u-flex--row au-u-flex--vertical-center au-u-flex-self-end"
             >
-              Naar boven
-            </AuButton>
-            <AuButton
-              @skin="naked"
-              @icon="nav-down"
-              @hideText={{true}}
-              {{on "click" (fn this.moveLabel label "down")}}
-            >
-              Naar onder
-            </AuButton>
-          </div>
+              <AuButton
+                @skin="naked"
+                @icon="nav-up"
+                @hideText={{true}}
+                {{on "click" (fn this.moveLabel label "up")}}
+              >
+                Naar boven
+              </AuButton>
+              <AuButton
+                @skin="naked"
+                @icon="nav-down"
+                @hideText={{true}}
+                {{on "click" (fn this.moveLabel label "down")}}
+              >
+                Naar onder
+              </AuButton>
+            </div>
+          {{/if}}
         </li>
       {{/each}}
     </ul>

--- a/addon/components/semantic-forms/table-column-configurator.js
+++ b/addon/components/semantic-forms/table-column-configurator.js
@@ -52,12 +52,12 @@ export default class SemanticFormsTableColumnConfiguratorComponent extends Compo
 
   @action
   moveLabel(label, upDown) {
-    const indexOfLabel = this.labels.indexOf(label);
+    const indexOfLabel = this.selectedLabels.indexOf(label);
     let switchLabel = null;
     if (upDown === 'up') {
-      switchLabel = this.labels.objectAt(indexOfLabel - 1);
+      switchLabel = A([...this.selectedLabels]).objectAt(indexOfLabel - 1);
     } else {
-      switchLabel = this.labels.objectAt(indexOfLabel + 1);
+      switchLabel = A([...this.selectedLabels]).objectAt(indexOfLabel + 1);
     }
 
     if (!switchLabel) {

--- a/addon/components/semantic-forms/table-column-configurator.js
+++ b/addon/components/semantic-forms/table-column-configurator.js
@@ -83,7 +83,11 @@ export default class SemanticFormsTableColumnConfiguratorComponent extends Compo
   }
 
   get selectedLabels() {
-    return this.labels?.filter((label) => label.isSelected) ?? [];
+    return (
+      this.labels
+        ?.filter((label) => label.isSelected)
+        .sort((a, b) => a.order - b.order) ?? []
+    );
   }
 
   get disabledSelection() {

--- a/addon/components/semantic-forms/table-column-configurator.js
+++ b/addon/components/semantic-forms/table-column-configurator.js
@@ -52,14 +52,18 @@ export default class SemanticFormsTableColumnConfiguratorComponent extends Compo
 
   @action
   moveLabel(label, upDown) {
-    const factor = upDown === 'up' ? -1 : 1;
-    let orderWithFactor = label.order + factor;
-    if (orderWithFactor === -1) {
-      orderWithFactor = this.labels.length - 1;
-    } else if (orderWithFactor === this.labels.length) {
-      orderWithFactor = 0;
+    const indexOfLabel = this.labels.indexOf(label);
+    let switchLabel = null;
+    if (upDown === 'up') {
+      switchLabel = this.labels.objectAt(indexOfLabel - 1);
+    } else {
+      switchLabel = this.labels.objectAt(indexOfLabel + 1);
     }
-    let switchLabel = this.labels.find((l) => l.order === orderWithFactor);
+
+    if (!switchLabel) {
+      return;
+    }
+
     this.labels.removeObjects([label, switchLabel]);
     this.labels.pushObjects([
       {

--- a/addon/services/semantic-form-repository.js
+++ b/addon/services/semantic-form-repository.js
@@ -234,18 +234,11 @@ export default class SemanticFormRepositoryService extends Service {
         size: size,
       };
     }
-
+    console.log({ newLabels });
     return {
       instances,
       formDefinition,
       labels: newLabels,
-      headers: newLabels.map((l) => {
-        return {
-          key: l.var,
-          label: l.name,
-          isCustom: !!l.isCustom,
-        };
-      }),
     };
   }
 

--- a/addon/services/semantic-form-repository.js
+++ b/addon/services/semantic-form-repository.js
@@ -234,7 +234,6 @@ export default class SemanticFormRepositoryService extends Service {
         size: size,
       };
     }
-    console.log({ newLabels });
     return {
       instances,
       formDefinition,

--- a/addon/services/semantic-form-repository.js
+++ b/addon/services/semantic-form-repository.js
@@ -197,8 +197,7 @@ export default class SemanticFormRepositoryService extends Service {
       filter = '',
       labels = [],
     } = options;
-    let sortedLabels = labels.sort((a, b) => a.order - b.order);
-    const labelsQueryParam = encodeURIComponent(JSON.stringify(sortedLabels));
+    const labelsQueryParam = encodeURIComponent(JSON.stringify(labels));
     const id = formDefinition.id;
     const response = await fetch(
       `/form-content/${id}/instances?page[size]=${size}&page[number]=${page}&sort=${sort}&filter=${filter}&labels=${labelsQueryParam}`
@@ -209,8 +208,6 @@ export default class SemanticFormRepositoryService extends Service {
       throw error;
     }
     const { instances, labels: newLabels } = await response.json();
-    sortedLabels = (newLabels || labels).sort((a, b) => a.order - b.order);
-
     instances.meta = instances.meta || {};
     instances.meta.count = parseInt(response.headers.get('X-Total-Count'), 10);
     instances.meta.pagination = {
@@ -241,8 +238,8 @@ export default class SemanticFormRepositoryService extends Service {
     return {
       instances,
       formDefinition,
-      labels: sortedLabels,
-      headers: sortedLabels.map((l) => {
+      labels: newLabels,
+      headers: newLabels.map((l) => {
         return {
           key: l.var,
           label: l.name,


### PR DESCRIPTION
## Description

- do not do an unnecessary sort of the labels
- let the instance table fetch the configurable labels instead of using the onces that where passed on by the arguments (this lets the configuration alsways fetch latest when table is loaded => more reactive)

## Note
 The configurable labels is possibly a BREAKING CHANGE 

## Links to other tickets

- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/578
- https://github.com/lblod/form-content-service/pull/86