### PR TITLE
LMB-1513 | Async custom validations

### DIFF
--- a/addon/components/semantic-forms/instance-table.hbs
+++ b/addon/components/semantic-forms/instance-table.hbs
@@ -73,7 +73,7 @@
     @page={{@page}}
     @size={{@size}}
     @isLoading={{not this.initialized}}
-    @noDataMessage="Geen instance gevonden."
+    @noDataMessage={{this.noDataMessage}}
     as |t|
   >
     <t.content as |c|>

--- a/addon/components/semantic-forms/instance-table.js
+++ b/addon/components/semantic-forms/instance-table.js
@@ -167,6 +167,10 @@ export default class FormInstanceTableComponent extends Component {
     return this.args.newFormRoute || 'forms.form.new';
   }
 
+  get noDataMessage() {
+    return this.args.noDataMessage || 'Geen instance gevonden.';
+  }
+
   willDestroy() {
     super.willDestroy(...arguments);
     this.labels.clear();

--- a/addon/components/semantic-forms/instance.hbs
+++ b/addon/components/semantic-forms/instance.hbs
@@ -16,7 +16,7 @@
         @useNewListingLayout={{true}}
         @lazyGenerators={{true}}
         @level={{2}}
-        class={{if @formClass @formClass "au-u-max-width-medium" }}
+        class={{if @formClass @formClass "au-u-max-width-medium"}}
       />
       {{yield}}
     </section>
@@ -27,14 +27,18 @@
       </AuAlert>
     {{/if}}
 
-
     {{#unless @show}}
       <AuToolbar as |Group|>
         <Group>
           <AuButtonGroup>
             <AuButton
               {{on "click" this.tryOpenHistoryModal}}
-              @disabled={{or this.save.isRunning (not this.hasChanges)}}
+              @disabled={{or
+                this.save.isRunning
+                this.isRunningValidationsOnForm
+                (not this.hasChanges)
+                (not this.isValidForm)
+              }}
               @loading={{this.save.isRunning}}
               @loadingMessage={{this.saveTitle}}
             >{{this.saveTitle}}</AuButton>

--- a/addon/components/semantic-forms/instance.hbs
+++ b/addon/components/semantic-forms/instance.hbs
@@ -39,8 +39,11 @@
                 (not this.hasChanges)
                 (not this.isValidForm)
               }}
-              @loading={{this.save.isRunning}}
-              @loadingMessage={{this.saveTitle}}
+              @loading={{or
+                this.save.isRunning
+                this.isRunningValidationsOnForm
+              }}
+              @loadingMessage={{this.saveButtonLoadingText}}
             >{{this.saveTitle}}</AuButton>
             <SemanticForms::SaveWithHistory
               @save={{perform this.save}}

--- a/addon/components/semantic-forms/instance.js
+++ b/addon/components/semantic-forms/instance.js
@@ -83,12 +83,7 @@ export default class InstanceComponent extends Component {
   @action
   async tryOpenHistoryModal() {
     this.forceShowErrors = !this.isValidForm;
-    // TODO this can go as user is not able to save when there are errors?
-    if (!this.isValidForm) {
-      this.errorMessage =
-        'Niet alle velden zijn correct ingevuld. Gelieve deze eerst te corrigeren.';
-      return;
-    }
+
     if (this.args.customHistoryMessage) {
       this.isSaveHistoryModalOpen = true;
     } else {

--- a/addon/components/semantic-forms/instance.js
+++ b/addon/components/semantic-forms/instance.js
@@ -81,7 +81,9 @@ export default class InstanceComponent extends Component {
 
   @action
   async tryOpenHistoryModal() {
-    const isValid = this.semanticFormRepository.isValidForm(this.formInfo);
+    const isValid = await this.semanticFormRepository.isValidForm(
+      this.formInfo
+    );
     this.forceShowErrors = !isValid;
     if (!isValid) {
       this.errorMessage =

--- a/addon/components/semantic-forms/instance.js
+++ b/addon/components/semantic-forms/instance.js
@@ -36,6 +36,17 @@ export default class InstanceComponent extends Component {
     return this.args.saveTitle || 'Pas aan';
   }
 
+  get saveButtonLoadingText() {
+    if (this.save.isRunning) {
+      return 'Opslaan';
+    }
+    if (this.isRunningValidationsOnForm) {
+      return 'Valideren';
+    }
+
+    return null;
+  }
+
   save = task({ keepLatest: true }, async () => {
     let ttlCode = this.sourceTriples;
     const instanceId = this.formInfo.instanceId;

--- a/addon/components/semantic-forms/new-instance.hbs
+++ b/addon/components/semantic-forms/new-instance.hbs
@@ -32,7 +32,11 @@
               (not this.isValidForm)
               this.isRunningValidationsOnForm
             }}
-            @loading={{this.save.isRunning}}
+            @loading={{or
+              this.save.isRunning
+              this.this.isRunningValidationsOnForm
+            }}
+            @loadingMessage={{this.saveButtonLoadingText}}
           >
             Bewaar
           </AuButton>

--- a/addon/components/semantic-forms/new-instance.hbs
+++ b/addon/components/semantic-forms/new-instance.hbs
@@ -28,6 +28,10 @@
         <AuButtonGroup>
           <AuButton
             {{on "click" (perform this.save)}}
+            @disabled={{or
+              (not this.isValidForm)
+              this.isRunningValidationsOnForm
+            }}
             @loading={{this.save.isRunning}}
           >
             Bewaar

--- a/addon/components/semantic-forms/new-instance.js
+++ b/addon/components/semantic-forms/new-instance.js
@@ -122,6 +122,17 @@ export default class NewInstanceComponent extends Component {
     this.formInfo?.formStore?.clearObservers();
   }
 
+  get saveButtonLoadingText() {
+    if (this.save.isRunning) {
+      return 'Opslaan';
+    }
+    if (this.isRunningValidationsOnForm) {
+      return 'Valideren';
+    }
+
+    return null;
+  }
+
   get isRunningValidationsOnForm() {
     return this.semanticFormRepository.validateForm?.isRunning;
   }

--- a/addon/components/semantic-forms/new-instance.js
+++ b/addon/components/semantic-forms/new-instance.js
@@ -33,7 +33,9 @@ export default class NewInstanceComponent extends Component {
   save = task({ keepLatest: true }, async () => {
     let ttlCode = this.sourceTriples;
     this.errorMessage = null;
-    const isValid = this.semanticFormRepository.isValidForm(this.formInfo);
+    const isValid = await this.semanticFormRepository.isValidForm(
+      this.formInfo
+    );
     this.forceShowErrors = !isValid;
     if (!isValid) {
       this.errorMessage =

--- a/addon/components/semantic-forms/new-instance.js
+++ b/addon/components/semantic-forms/new-instance.js
@@ -35,13 +35,7 @@ export default class NewInstanceComponent extends Component {
   save = task({ keepLatest: true }, async () => {
     let ttlCode = this.sourceTriples;
     this.errorMessage = null;
-    // TODO this can go as user is not able to save when there are errors?
     this.forceShowErrors = !this.isValidForm;
-    if (!this.isValidForm) {
-      this.errorMessage =
-        'Niet alle velden zijn correct ingevuld. Probeer het later opnieuw.';
-      return;
-    }
 
     if (this.args.beforeCreate) {
       try {

--- a/addon/services/semantic-form-repository.js
+++ b/addon/services/semantic-form-repository.js
@@ -152,7 +152,7 @@ export default class SemanticFormRepositoryService extends Service {
     return def;
   }
 
-  isValidForm(formInfo) {
+  async isValidForm(formInfo) {
     if (this._isFormInfo(formInfo)) {
       return false;
     }

--- a/addon/services/semantic-form-repository.js
+++ b/addon/services/semantic-form-repository.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import { timeout } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 import { JSON_API_TYPE, RESOURCE_CACHE_TIMEOUT } from '../utils/constants';
 import { validateForm } from '@lblod/ember-submission-form-fields';
 import { tracked } from '@glimmer/tracking';
@@ -163,6 +163,25 @@ export default class SemanticFormRepositoryService extends Service {
       store: formInfo.formStore,
     });
   }
+
+  validateForm = task({ keepLatest: true }, async (formInfo, cb = null) => {
+    await timeout(250);
+    if (this._isFormInfo(formInfo)) {
+      return false;
+    }
+
+    const isValid = await validateForm(formInfo.formNode, {
+      ...formInfo.graphs,
+      sourceNode: formInfo.sourceNode,
+      store: formInfo.formStore,
+    });
+
+    if (cb) {
+      cb(isValid);
+    }
+
+    return isValid;
+  });
 
   _isFormInfo(formInfo) {
     if (!formInfo) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@embroider/test-setup": "^2.1.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-submission-form-fields": "~2.26.2",
+        "@lblod/ember-submission-form-fields": "~3.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.0.1",
         "ember-auto-import": "^2.6.3",
@@ -67,7 +67,7 @@
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^2.15.0 || ^3.0.0",
-        "@lblod/ember-submission-form-fields": "~2.26.2",
+        "@lblod/ember-submission-form-fields": "3.0.0",
         "ember-source": "^3.0.0 || ^4.0.0 || ^5.0.0",
         "uuid": "^9.0.0"
       }
@@ -3708,23 +3708,21 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.26.2.tgz",
-      "integrity": "sha512-h3ZC1GsR5NLvs+NT5lrDbP4F8LnyTrjS2AJ4M1qwOg8q6KwzG5JuUzYqzjlH14iHp1JfW3vM4Iup1gA/PVLAOg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-3.0.0.tgz",
+      "integrity": "sha512-anebrpTv4eets/yWvLMBPdMwlm0JD8yOqwmeTGbcGJ52sWzs3GkYszlgIyr2JXq0DFW81QnmLeluHjU3vC/a4A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "7.26.0",
-        "@embroider/macros": "^1.13.5",
-        "@lblod/submission-form-helpers": "^2.10.2",
         "client-zip": "^2.4.4",
         "clipboardy": "^4.0.0",
         "ember-auto-import": "^2.8.1",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-version-checker": "^5.1.2",
-        "ember-concurrency": "^2.3.2 || ^3.0.0 || ^4.0.2",
+        "ember-concurrency": "^4.0.2",
         "ember-modifier": "^4.1.0",
-        "ember-truth-helpers": "^3.0.0 || ^4.0.0",
+        "ember-truth-helpers": "^4.0.0",
         "forking-store": "^2.0.0",
         "rdflib": "^2.2.19",
         "uuid": "^9.0.0"
@@ -3733,8 +3731,9 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.15.0 || ^3.7.0",
-        "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
+        "@appuniversum/ember-appuniversum": "^3.7.0",
+        "@lblod/submission-form-helpers": "^3.0.0",
+        "ember-data": "^5.0.0",
         "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "ember-source": ">= 4.0.0"
       }
@@ -3746,26 +3745,6 @@
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "node_modules/@lblod/ember-submission-form-fields/node_modules/@lblod/submission-form-helpers": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.3.tgz",
-      "integrity": "sha512-rgRRu1LS+Hltkto3b27xBLyBCYoVfuYfaJ/MHnXhQJ1mvcje4PUP1yQoXclXV/dDnXa91S+SPrBQs9SIyYy9jA==",
-      "dev": true,
-      "dependencies": {
-        "iban": "0.0.14",
-        "libphonenumber-js": "^1.9.6",
-        "moment": "^2.24.0",
-        "rdflib": "^2.2.19",
-        "uuid": "^9.0.0",
-        "validator": "^13.5.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "forking-store": "^2.0.0"
       }
     },
     "node_modules/@lblod/ember-submission-form-fields/node_modules/async-disk-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@lblod/submission-form-helpers": "~2.10.2",
+        "@lblod/submission-form-helpers": "~3.0.0",
         "ember-auto-import": "^2.7.2",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.2.0",
@@ -3748,6 +3748,26 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "node_modules/@lblod/ember-submission-form-fields/node_modules/@lblod/submission-form-helpers": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.3.tgz",
+      "integrity": "sha512-rgRRu1LS+Hltkto3b27xBLyBCYoVfuYfaJ/MHnXhQJ1mvcje4PUP1yQoXclXV/dDnXa91S+SPrBQs9SIyYy9jA==",
+      "dev": true,
+      "dependencies": {
+        "iban": "0.0.14",
+        "libphonenumber-js": "^1.9.6",
+        "moment": "^2.24.0",
+        "rdflib": "^2.2.19",
+        "uuid": "^9.0.0",
+        "validator": "^13.5.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "forking-store": "^2.0.0"
+      }
+    },
     "node_modules/@lblod/ember-submission-form-fields/node_modules/async-disk-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
@@ -4152,9 +4172,9 @@
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-2.10.2.tgz",
-      "integrity": "sha512-ftc5T/sLpXFvRIdPR0QlZybQJJAoTleo1l6lEZ35ezuXG3h915G+WeCuq+PZMyPGo9d3deGE4pDA5H0D4q8qVQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lblod/submission-form-helpers/-/submission-form-helpers-3.0.0.tgz",
+      "integrity": "sha512-EXvGpjoLoNHh0IAvGzynciB48v3YH3eqExDuiKzWgrLc0UkcSHDFZAQLf3XnH1LH9793PLnIMaC2CE9Mi0isYQ==",
       "dependencies": {
         "iban": "0.0.14",
         "libphonenumber-js": "^1.9.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-submission-form-fields": "~2.26.2",
+    "@lblod/ember-submission-form-fields": "~3.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",
     "ember-auto-import": "^2.6.3",
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^2.15.0 || ^3.0.0",
-    "@lblod/ember-submission-form-fields": "~2.26.2",
+    "@lblod/ember-submission-form-fields": "3.0.0",
     "uuid": "^9.0.0",
     "ember-source": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@lblod/submission-form-helpers": "~2.10.2",
+    "@lblod/submission-form-helpers": "~3.0.0",
     "ember-auto-import": "^2.7.2",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",


### PR DESCRIPTION
## Description

Our form fields can have custom validations but they are only synchronous what is a limit some times. I update the addon packages so they can now work with asynchronous custom validation rules. This package will validate the form before saving it. We want that the user cannot save the form when it has failing validations

## How to test

1. In the frontend app
2. Fill in an invalid value 
3. The error should show
4. You should not be able to save the form while it is being validated
5. The form cannot be saved when invalid overall

⚠️  Use yalc to connect to the local branches of each PR

## Links to other PR's

- https://github.com/lblod/ember-submission-form-fields/pull/207
- https://github.com/lblod/submission-form-helpers/pull/71
- https://github.com/lblod/frontend-lokaal-mandatenbeheer/pull/583
